### PR TITLE
Excludes changed files that are not in the coverage report instead of…

### DIFF
--- a/coverageOnDiff.js
+++ b/coverageOnDiff.js
@@ -122,19 +122,6 @@ coverageOnDiff.evaluateCodeCoverage = (coverage, newLine) => {
       diffCodeCoverage[file].lines = changedLines;
       diffCodeCoverage[file].stmt = changedStmtCoverage(coverage[file], changedLines);
       diffCodeCoverage[file].branch = changedBranchCoverage(coverage[file], changedLines);
-    } else {
-      diffCodeCoverage[file] = {};
-      diffCodeCoverage[file].lines = changedLines;
-      diffCodeCoverage[file].stmt = {
-        nCovered: 0,
-        nUncovered: changedLines.length,
-        coveredLines: [],
-        unCoveredLines: changedLines,
-      };
-      diffCodeCoverage[file].branch = {
-        nCovered: 0,
-        nUncovered: changedLines.length,
-      };
     }
   }
   return diffCodeCoverage;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coverage-on-diff",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A tool to get code coverage on new lines added based on a diff",
   "main": "index.js",
   "scripts": {

--- a/test/testCoverageOnDiff.js
+++ b/test/testCoverageOnDiff.js
@@ -90,27 +90,13 @@ describe('CoverageOnDiff Test', () => {
       });
     });
 
-    it('should default to no code coverage if file does not exist in ', () => {
+    it('should not include changed files that are not in the coverage', () => {
       const diffCodeCoverage = coverageOnDiff.evaluateCodeCoverage(dataFactory.getParsedCodeCoverage(), {
         'buster/dummyUtil.js': [10],
       });
       changedStmtCoverageStub.should.not.be.calledOnce();
       changedBranchCoverageStub.should.not.be.calledOnce();
-      diffCodeCoverage.should.eql({
-        'buster/dummyUtil.js': {
-          lines: [10],
-          stmt: {
-            nCovered: 0,
-            nUncovered: 1,
-            coveredLines: [],
-            unCoveredLines: [10],
-          },
-          branch: {
-            nCovered: 0,
-            nUncovered: 1,
-          },
-        },
-      });
+      diffCodeCoverage.should.not.have.property('buster/dummyUtil.js');
     });
   });
 


### PR DESCRIPTION
Previous implementation reported non-covered files that appeared in the diff as having 0% coverage. Addresses #1 