### PR TITLE
upgraded parse diff version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chalk": "^2.4.1",
     "fs": "0.0.1-security",
     "lodash": "^4.17.11",
-    "parse-diff": "^0.5.1",
+    "parse-diff": "^0.11.1",
     "path": "^0.12.7",
     "table": "^5.1.0",
     "yargs": "^17.1.1"


### PR DESCRIPTION
Need to upgrade parse diff library since the parseDIff function from the parse-diff library in the 0.5.1 version sometimes returns a file in the diff array which lacks a `to` property as shown in the picture below

<img width="1272" alt="image" src="https://github.com/classy-org/coverage-on-diff/assets/31252332/603673fb-f087-4b67-9d87-ce89060ebd01">

which then goes on to throw the error 

<img width="849" alt="image" src="https://github.com/classy-org/coverage-on-diff/assets/31252332/b44dd0e5-5998-4c62-a748-88d7ee655d74">

as per the code on Line 13

<img width="966" alt="image" src="https://github.com/classy-org/coverage-on-diff/assets/31252332/56faccb8-89d7-4077-9099-ff6f15dcc8d6">

Would appreciate if you could merge this PR and publish it