### PR TITLE
feat(report): add support for listing uncovered branch lines

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -120,10 +120,11 @@ try {
    */
   if (argv.report.includes('text')) {
     const data = [];
-    data.push(['File', '% Stmt', '% Branch', 'Uncovered Line #s', 'Lines Changed']);
+    data.push(['File', '% Stmt', '% Branch', 'Uncovered Line #s', 'Uncovered Branch Line #s', 'Lines Changed']);
     data.push(['All changed files',
       getColorMessage(totalStmtPercentage, `${totalStmtPercentage}%`),
       getColorMessage(totalBranchPercentage, `${totalBranchPercentage}%`),
+      '',
       '',
       '']);
 
@@ -140,6 +141,7 @@ try {
         getColorMessage(stmtPercentage, `${stmtPercentage}%`),
         getColorMessage(branchPercentage, `${branchPercentage}%`),
         value.stmt.unCoveredLines.toString(),
+        value.branch.unCoveredLines.toString(),
         value.lines]);
     });
     const options = {

--- a/coverageOnDiff.js
+++ b/coverageOnDiff.js
@@ -98,12 +98,16 @@ function changedBranchCoverage(coverage, changedLines) {
 
   let nCovered = 0;
   let nUncovered = 0;
+  const changedCoveredLines = [];
+  const unchangedCoveredLines = [];
 
   for (const line of changedLines) {
     if (coveredLines.includes(line)) {
+      changedCoveredLines.push(line);
       nCovered++;
     }
     if (uncoveredLines.includes(line)) {
+      unchangedCoveredLines.push(line);
       nUncovered++;
     }
   }
@@ -111,6 +115,8 @@ function changedBranchCoverage(coverage, changedLines) {
   return {
     nCovered,
     nUncovered,
+    coveredLines: changedCoveredLines,
+    unCoveredLines: unchangedCoveredLines,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coverage-on-diff",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A tool to get code coverage on new lines added based on a diff",
   "main": "index.js",
   "scripts": {

--- a/test/testCoverageOnDiff.js
+++ b/test/testCoverageOnDiff.js
@@ -174,6 +174,8 @@ describe('CoverageOnDiff Test', () => {
         result.should.eql({
           nCovered: 0,
           nUncovered: 0,
+          coveredLines: [],
+          unCoveredLines: [],
         });
       });
       it('should have covered branch changes', () => {
@@ -181,6 +183,8 @@ describe('CoverageOnDiff Test', () => {
         result.should.eql({
           nCovered: 1,
           nUncovered: 0,
+          coveredLines: [10],
+          unCoveredLines: [],
         });
       });
       it('should have uncovered branch changes', () => {
@@ -188,6 +192,8 @@ describe('CoverageOnDiff Test', () => {
         result.should.eql({
           nCovered: 0,
           nUncovered: 1,
+          coveredLines: [],
+          unCoveredLines: [15],
         });
       });
       it('should be uncovered branch when there is at least 1 uncovered path', () => {
@@ -195,6 +201,8 @@ describe('CoverageOnDiff Test', () => {
         result.should.eql({
           nCovered: 0,
           nUncovered: 1,
+          coveredLines: [],
+          unCoveredLines: [30],
         });
       });
     });


### PR DESCRIPTION
**Enhancement: Enhance Report Visibility with Uncovered Branch Line Details**

The current coverage report provides valuable insights, including File, % Stmt, % Branch, Uncovered Line #s, and Lines Changed. However, it lacks visibility into Uncovered Branch Line #s. This pull request addresses this gap, ensuring a more comprehensive and informative report. Now, the developers can directly view the uncovered branch lines in the pull request.